### PR TITLE
fix reconnecting with exponential backoff

### DIFF
--- a/Primus/Primus.m
+++ b/Primus/Primus.m
@@ -185,9 +185,9 @@ NSTimeInterval const kBackgroundFetchIntervalMinimum = 600;
 
         _readyState = kPrimusReadyStateClosed;
 
-        [_timers clearAll];
 
         if ([intentional isEqualToString:@"primus::server::close"]) {
+            [_timers clearAll];
             return [self emit:@"end"];
         }
 
@@ -195,6 +195,8 @@ NSTimeInterval const kBackgroundFetchIntervalMinimum = 600;
 
         if ([self.options.reconnect.strategies containsObject:@(kPrimusReconnectionStrategyDisconnect)]) {
             [self reconnect];
+        } else {
+            [_timers clearAll];
         }
     }];
 }


### PR DESCRIPTION
Hey Seegno,

I was having difficulty getting the exponential backoff working. I think this fixes the logic. Essentially a reconnect would be scheduled, the `backoff` bit is flipped saying that it was scheduled, then it would clear the timers, and try to reconnect but the `backoff` bit was set to true so it would just return. Hope this makes sense.

What would happen before is this:
1) the kPrimusReconnectionStrategyTimeout would kick in
 it would schedule a timer and set backoff=YES
2) then the kPrimusReconnectionStrategyDisconnect would kick in
 it would have cleared all the timeouts, but since backoff is YES
 it would not schedule a new reconnect attempt

This fixes it by only clearing the timers when
1) the server intentionally closes the connection
2) we should not reconnect on disconnect <-- I think this logic is correct here