### PR TITLE
Reverse the direction of ping/pong messages

### DIFF
--- a/Primus/Core/PrimusConnectOptions.h
+++ b/Primus/Core/PrimusConnectOptions.h
@@ -12,9 +12,8 @@
 
 @property (nonatomic) PrimusReconnectOptions *reconnect; // Stores the back off configuration
 @property (nonatomic) NSArray *strategy;                 // Default reconnect strategies
-@property (nonatomic) NSTimeInterval timeout;            // Connection timeout duration
-@property (nonatomic) NSTimeInterval ping;               // Heartbeat ping interval
-@property (nonatomic) NSTimeInterval pong;               // Heartbeat pong response timeout.
+@property (nonatomic) NSTimeInterval pingInterval;            // Interval at which heartbeats are sent
+@property (nonatomic) NSTimeInterval pingTimeout;               // Max time to wait for a server ping
 @property (nonatomic) BOOL autodetect;                   // Autodetect transformer and parser
 @property (nonatomic) BOOL manual;                       // Manual connection
 @property (nonatomic) BOOL stayConnectedInBackground;    // Stay connected while app is in background

--- a/Primus/Core/PrimusConnectOptions.m
+++ b/Primus/Core/PrimusConnectOptions.m
@@ -32,9 +32,8 @@
     if (self) {
         _reconnect = [[PrimusReconnectOptions alloc] init];
         _strategy = strategy ?: [NSArray array];
-        _timeout = 10;
-        _ping = 25;
-        _pong = 10;
+        _pingTimeout = 45;
+        _pingInterval = 30;
         _autodetect = YES;
         _manual = NO;
         _stayConnectedInBackground = [[NSBundle.mainBundle objectForInfoDictionaryKey:@"UIBackgroundModes"] containsObject:@"voip"];
@@ -49,7 +48,7 @@
 
         // Set the ping time to 10 minutes and 25 seconds
         if (_stayConnectedInBackground) {
-            _ping = 625;
+            _pingTimeout = 625;
         }
     }
 

--- a/Primus/Core/PrimusTimers.h
+++ b/Primus/Core/PrimusTimers.h
@@ -11,8 +11,7 @@
 @interface PrimusTimers : NSObject
 
 @property (nonatomic) GCDTimer *open;
-@property (nonatomic) GCDTimer *ping;
-@property (nonatomic) GCDTimer *pong;
+@property (nonatomic) GCDTimer *heartbeat;
 @property (nonatomic) GCDTimer *connect;
 @property (nonatomic) GCDTimer *reconnect;
 

--- a/Primus/Core/PrimusTimers.m
+++ b/Primus/Core/PrimusTimers.m
@@ -13,8 +13,7 @@
 - (void)invalidateAll
 {
     [self.open invalidate];
-    [self.ping invalidate];
-    [self.pong invalidate];
+    [self.heartbeat invalidate];
     [self.connect invalidate];
     [self.reconnect invalidate];
 }
@@ -24,8 +23,7 @@
     [self invalidateAll];
 
     self.open = nil;
-    self.ping = nil;
-    self.pong = nil;
+    self.heartbeat = nil;
     self.connect = nil;
     self.reconnect = nil;
 }


### PR DESCRIPTION
Due to modern browse implementations, Primus has switched to server-side pings.
See: https://github.com/primus/primus/pull/534